### PR TITLE
fix: preserve fallback assets and align Fabric source defaults

### DIFF
--- a/src/FastImageViewNativeComponent.ts
+++ b/src/FastImageViewNativeComponent.ts
@@ -9,7 +9,7 @@ import type {
 
 type Headers = ReadonlyArray<Readonly<{ name: string; value: string }>>
 type Priority = WithDefault<'low' | 'normal' | 'high', 'normal'>
-type CacheControl = WithDefault<'immutable' | 'web' | 'cacheOnly', 'web'>
+type CacheControl = WithDefault<'immutable' | 'web' | 'cacheOnly', 'immutable'>
 type Transition = WithDefault<'fade' | 'none', 'none'>
 
 type FastImageSource = Readonly<{

--- a/src/NativeFastImageViewModule.ts
+++ b/src/NativeFastImageViewModule.ts
@@ -1,6 +1,6 @@
 import type { TurboModule } from 'react-native'
 import { TurboModuleRegistry } from 'react-native'
-import { Source } from './index'
+import type { Source } from './index'
 
 export interface Spec extends TurboModule {
     preload: (sources: Source[]) => void

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -17,6 +17,13 @@ export type OnProgressEvent = SyntheticEvent<
     |}>,
 >
 
+export type OnErrorEvent = SyntheticEvent<$ReadOnly<{ error: string }>>
+
+export type Transition = $ReadOnly<{|
+    fade: 'fade',
+    none: 'none',
+|}>
+
 export type ResizeMode = $ReadOnly<{|
     contain: 'contain',
     cover: 'cover',
@@ -50,7 +57,7 @@ export type FastImageSource = {
 
 export type FastImageProps = $ReadOnly<{|
     ...ViewProps,
-    onError?: ?() => void,
+    onError?: ?(event: OnErrorEvent) => void,
     onLoad?: ?(event: OnLoadEvent) => void,
     onLoadEnd?: ?() => void,
     onLoadStart?: ?() => void,
@@ -63,6 +70,7 @@ export type FastImageProps = $ReadOnly<{|
     blurRadius?: number,
     resizeMode?: ?ResizeModes,
     fallback?: ?boolean,
+    transition?: ?$Values<Transition>,
     testID?: ?string,
 |}>
 
@@ -70,6 +78,7 @@ declare export default class FastImage extends React$Component<FastImageProps> {
     static resizeMode: ResizeMode;
     static priority: Priority;
     static cacheControl: CacheControl;
+    static transition: Transition;
     static preload: PreloadFn;
     static clearMemoryCache: () => Promise<void>;
     static clearDiskCache: () => Promise<void>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -204,9 +204,18 @@ function FastImageBase({
     ...props
 }: FastImageProps & { forwardedRef: React.Ref<any> }) {
     if (fallback) {
-        const cleanedSource = { ...(source as any) }
-        delete cleanedSource.cache
-        const resolvedSource = Image.resolveAssetSource(cleanedSource)
+        let cleanedSource:
+            | Omit<Source, 'cache'>
+            | ImageRequireSource
+            | undefined = source
+        if (source && typeof source === 'object') {
+            const imageSource = { ...source }
+            delete imageSource.cache
+            cleanedSource = imageSource
+        }
+        const resolvedSource = cleanedSource
+            ? Image.resolveAssetSource(cleanedSource)
+            : undefined
 
         return (
             <View style={[styles.imageContainer, style]} ref={forwardedRef}>


### PR DESCRIPTION
## Summary:

**Observable cache behavior:** Fabric's omitted cache option changes from `web` to the documented `immutable` default used by the legacy implementation. Apps that deliberately need HTTP-refresh behavior should set `source.cache = FastImage.cacheControl.web` explicitly. Explicit cache modes are unchanged. Fallback accepts numeric assets and absent sources correctly; Flow declarations gain existing runtime fields.

Preserve numeric require() assets in fallback mode, strip only Fast Image's cache option without mutating source objects, align Fabric's cache default with the documented immutable default, and align Flow declarations with the exported transition/error API.

## Changelog:

- [GENERAL] [FIXED] - preserve fallback assets and align Fabric source defaults

## Test Plan:

Eight actual React rendering cases (iOS/Android × numeric/absent/null/frozen-object source): six baseline mismatches become zero. RN 0.87 codegen confirms omitted cache changes from web to immutable. Flow declaration parsing succeeds.

- Existing upstream Jest: 7 tests / 7 snapshots pass; lint, type-check, TypeScript build, and git diff --check pass on the combined review branch.
- React Doctor: 100/100 for changed React files.
- Diagnostic harnesses are isolated and not checked-in test files. Physical-device, signed-release, and pixel-level rendering checks were not performed.
- Applicable fixes are backported to published 8.13.0 in consumer commit c96bba89a3de647844e29627eb57e24454323cda, retaining release native dependency declarations and excluding the newer main-only Java raw-resource implementation. Consumer checks pass: immutable install, ESLint, both products on Android Debug and iOS arm64 Simulator Debug, four release-mode Metro bundles, 13 web targets and four browser extensions. Generated Fabric cache default is verified. No physical-device/signed-release check is claimed.
