### PR TITLE
perf(ios): reuse image coders and the blur rendering context

### DIFF
--- a/ios/FastImage/FFFastImageBlurTransformation.mm
+++ b/ios/FastImage/FFFastImageBlurTransformation.mm
@@ -15,7 +15,13 @@ static const CGFloat BLUR_MAX_INPUT = 200.0;
 }
 
 - (UIImage *)transform:(UIImage *)image {
-    CIContext *context = [CIContext contextWithOptions:nil];
+    if (!image.CGImage) return image;
+
+    static CIContext *context;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        context = [CIContext contextWithOptions:nil];
+    });
 
     CIImage *input = [CIImage imageWithCGImage:image.CGImage];
 

--- a/ios/FastImage/FFFastImageView.mm
+++ b/ios/FastImage/FFFastImageView.mm
@@ -115,11 +115,14 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
 - (void)commonInitUtils {
     self.resizeMode = RCTResizeModeCover;
     self.clipsToBounds = YES;
-    [[SDImageCodersManager sharedManager] addCoder:[SDImageAVIFCoder sharedCoder]];
-    [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]];
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [[SDImageCodersManager sharedManager] addCoder:[SDImageAVIFCoder sharedCoder]];
+        [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]];
 #if !defined(DISABLE_SVG) || DISABLE_SVG == 0
-    [[SDImageCodersManager sharedManager] addCoder:[SDImageSVGCoder sharedCoder]];
+        [[SDImageCodersManager sharedManager] addCoder:[SDImageSVGCoder sharedCoder]];
 #endif
+    });
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {


### PR DESCRIPTION
## Summary:

No intended rendering/API change for supported CGImage-backed inputs. Nil/non-CGImage inputs are returned unchanged rather than passed to Core Image with a null CGImage. CIFilter objects remain local to each render.

Register the AVIF/WebP/SVG coders once instead of appending duplicates on each view initialization; reuse a thread-safe CIContext across blur operations and return safely for images without a CGImage.

## Changelog:

- [IOS] [CHANGED] - reuse image coders and the blur rendering context

## Test Plan:

Compiled the actual initialization paths with Foundation and counting dependency doubles: 100 view initializations register three coders instead of 300; 100 blur initializations create one context instead of 100; empty inputs create none. These are resource-lifetime checks, not a visual rendering benchmark. Apple's [CIContext documentation](https://developer.apple.com/documentation/coreimage/cicontext) confirms context reuse and concurrent rendering are supported; the SDK's addCoder implementation does append duplicates.

- Existing upstream Jest: 7 tests / 7 snapshots pass; lint, type-check, TypeScript build, and git diff --check pass on the combined review branch.
- React Doctor: 100/100 for changed React files.
- Diagnostic harnesses are isolated and not checked-in test files. Physical-device, signed-release, and pixel-level rendering checks were not performed.
- Applicable fixes are backported to published 8.13.0 in consumer commit c96bba89a3de647844e29627eb57e24454323cda, retaining release native dependency declarations and excluding the newer main-only Java raw-resource implementation. Consumer checks pass: immutable install, ESLint, both products on Android Debug and iOS arm64 Simulator Debug, four release-mode Metro bundles, 13 web targets and four browser extensions. Generated Fabric cache default is verified. No physical-device/signed-release check is claimed.
