### PR TITLE
fix(android): validate image sources and support headless cache operations

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageSource.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageSource.java
@@ -9,6 +9,8 @@ import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.Headers;
 import com.facebook.react.views.imagehelper.ImageSource;
 
+import java.util.Locale;
+
 import javax.annotation.Nullable;
 
 public class FastImageSource {
@@ -126,7 +128,7 @@ public class FastImageSource {
         boolean resourceNotFound = rawResId == 0;
 
         if (resourceNotFound) {
-            return null;
+            return Uri.EMPTY;
         }
 
         String rawResourceUri = ANDROID_RESOURCE_SCHEME + "://" +
@@ -138,13 +140,13 @@ public class FastImageSource {
     /**
      * Converts a source name to Android resource name format.
      * Android resources must be lowercase and cannot contain hyphens.
-     * Hyphens are removed to match React Native's bundling behavior.
+     * Hyphens are replaced with underscores to match React Native's resource lookup.
      *
      * @param source Original source name
      * @return Android-compatible resource name
      */
     private String toAndroidResourceName(String source) {
-        return source.toLowerCase().replace("-", "");
+        return source.toLowerCase(Locale.ROOT).replace("-", "_");
     }
 
     public boolean isBase64Resource() {

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -55,9 +55,13 @@ class FastImageViewConverter {
     // Resolve the source uri to a file path that android understands.
     static @Nullable
     FastImageSource getImageSource(Context context, @Nullable ReadableMap source) {
-        return source == null
+        if (source == null || !source.hasKey("uri") || source.isNull("uri")) {
+            return null;
+        }
+        String uri = source.getString("uri");
+        return uri == null || uri.trim().isEmpty()
                 ? null
-                : new FastImageSource(context, source.getString("uri"), getHeaders(source));
+                : new FastImageSource(context, uri, getHeaders(source));
     }
 
     static Headers getHeaders(ReadableMap source) {
@@ -144,7 +148,7 @@ class FastImageViewConverter {
 
         options = FastImageBlurHelper.transform(context, options, imageOptions);
 
-        if (imageSource.isResource()) {
+        if (imageSource != null && imageSource.isResource()) {
             // Every local resource (drawable) in Android has its own unique numeric id, which are
             // generated at build time. Although these ids are unique, they are not guaranteed unique
             // across builds. The underlying glide implementation caches these resources. To make

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModuleImplementation.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModuleImplementation.java
@@ -1,19 +1,15 @@
 package com.dylanvann.fastimage;
 
-import android.app.Activity;
-
-import androidx.annotation.NonNull;
-
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.RequestManager;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.views.imagehelper.ImageSource;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UiThreadUtil;
 
 class FastImageViewModuleImplementation {
-    ReactApplicationContext reactContext;
+    private final ReactApplicationContext reactContext;
     FastImageViewModuleImplementation(ReactApplicationContext reactContext){
 
     this.reactContext = reactContext;
@@ -21,36 +17,26 @@ class FastImageViewModuleImplementation {
 
     public static final String REACT_CLASS = "FastImageViewModule";
 
-    private Activity getCurrentActivity(){
-        return reactContext.getCurrentActivity();
-    }
-
     public void preload(final ReadableArray sources) {
-        final Activity activity = getCurrentActivity();
-        if (activity == null) return;
-        activity.runOnUiThread(new Runnable() {
+        UiThreadUtil.runOnUiThread(new Runnable() {
             @Override
             public void run() {
+                RequestManager manager = Glide.with(reactContext);
                 for (int i = 0; i < sources.size(); i++) {
                     final ReadableMap source = sources.getMap(i);
-                    final FastImageSource imageSource = FastImageViewConverter.getImageSource(activity, source);
-                    if (source == null || !source.hasKey("uri") || source.getString("uri").isEmpty()) {
-                            System.out.println("Source is null or URI is empty");
-                            continue;
-                          }
-                    Glide
-                            .with(activity.getApplicationContext())
+                    final FastImageSource imageSource = FastImageViewConverter.getImageSource(reactContext, source);
+                    if (imageSource == null || imageSource.getUri().toString().isEmpty()) {
+                        continue;
+                    }
+                    manager
                             // This will make this work for remote and local images. e.g.
                             //    - file:///
                             //    - content://
                             //    - res:/
                             //    - android.resource://
                             //    - data:image/png;base64
-                            .load(
-                                    imageSource.isBase64Resource() ? imageSource.getSource() :
-                                    imageSource.isResource() ? imageSource.getUri() : imageSource.getGlideUrl()
-                            )
-                            .apply(FastImageViewConverter.getOptions(activity, imageSource, source, null))
+                            .load(imageSource.getSourceForLoad())
+                            .apply(FastImageViewConverter.getOptions(reactContext, imageSource, source, null))
                             .preload();
                 }
             }
@@ -58,28 +44,24 @@ class FastImageViewModuleImplementation {
     }
 
     public void clearMemoryCache(final Promise promise) {
-        final Activity activity = getCurrentActivity();
-        if (activity == null) {
-            promise.resolve(null);
-            return;
-        }
-
-        activity.runOnUiThread(new Runnable() {
+        UiThreadUtil.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                Glide.get(activity.getApplicationContext()).clearMemory();
-                promise.resolve(null);
+                try {
+                    Glide.get(reactContext).clearMemory();
+                    promise.resolve(null);
+                } catch (Exception error) {
+                    promise.reject("E_CLEAR_MEMORY_CACHE", error);
+                }
             }
         });
     }
     public void clearDiskCache(Promise promise) {
-        final Activity activity = getCurrentActivity();
-        if (activity == null) {
+        try {
+            Glide.get(reactContext).clearDiskCache();
             promise.resolve(null);
-            return;
+        } catch (Exception error) {
+            promise.reject("E_CLEAR_DISK_CACHE", error);
         }
-
-        Glide.get(activity.getApplicationContext()).clearDiskCache();
-        promise.resolve(null);
     }
 }


### PR DESCRIPTION
## Summary:

No JS signature changes. Calls without an Activity now perform their requested work instead of resolving/skipping silently. Cache-clear failures reject with E_CLEAR_MEMORY_CACHE/E_CLEAR_DISK_CACHE. Missing preload sources are skipped. Raw-resource lookup on current main now matches RN's hyphen-to-underscore convention.

Validate missing/null/blank URIs before constructing a source; permit defaultSource-only options; preserve an empty URI for missing raw resources and use locale-independent React Native resource-name normalization. Preload and cache clearing use the React application context rather than silently doing nothing without an Activity. Reuse one RequestManager per preload batch and getSourceForLoad() for local/content/data models; report cache-clear failures through Promise rejection.

## Changelog:

- [ANDROID] [FIXED] - validate image sources and support headless cache operations

## Test Plan:

Both-architecture Java API compilation passes. Compiled actual module and converter methods with host doubles: three invalid-source failures become zero; headless memory/disk clears each execute once instead of zero; three valid preload models execute instead of zero, with correct file/content/remote model types; injected cache-clear failures reject.

- Existing upstream Jest: 7 tests / 7 snapshots pass; lint, type-check, TypeScript build, and git diff --check pass on the combined review branch.
- React Doctor: 100/100 for changed React files.
- Diagnostic harnesses are isolated and not checked-in test files. Physical-device, signed-release, and pixel-level rendering checks were not performed.
- Applicable fixes are backported to published 8.13.0 in consumer commit c96bba89a3de647844e29627eb57e24454323cda, retaining release native dependency declarations and excluding the newer main-only Java raw-resource implementation. Consumer checks pass: immutable install, ESLint, both products on Android Debug and iOS arm64 Simulator Debug, four release-mode Metro bundles, 13 web targets and four browser extensions. Generated Fabric cache default is verified. No physical-device/signed-release check is claimed.
