### PR TITLE
fix(android): scope requests and progress tracking to each image view

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
@@ -7,12 +7,9 @@ import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.ImageViewTarget;
 import com.bumptech.glide.request.target.Target;
-import com.facebook.react.bridge.WritableMap;
 import com.dylanvann.fastimage.events.FastImageErrorEvent;
 import com.dylanvann.fastimage.events.FastImageLoadEndEvent;
 import com.dylanvann.fastimage.events.FastImageLoadEvent;
-import com.dylanvann.fastimage.events.FastImageProgressEvent;
-import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.EventDispatcher;
@@ -21,22 +18,12 @@ public class FastImageRequestListener<T extends Drawable> implements RequestList
     static final String REACT_ON_ERROR_EVENT = "onFastImageError";
     static final String REACT_ON_LOAD_EVENT = "onFastImageLoad";
     static final String REACT_ON_LOAD_END_EVENT = "onFastImageLoadEnd";
-    private final String key;
 
-    FastImageRequestListener(String key) {
-        this.key = key;
-    }
-
-    private static WritableMap mapFromResource(Drawable resource) {
-        WritableMap resourceData = new WritableNativeMap();
-        resourceData.putInt("width", resource.getIntrinsicWidth());
-        resourceData.putInt("height", resource.getIntrinsicHeight());
-        return resourceData;
+    public FastImageRequestListener(String key) {
     }
 
     @Override
     public boolean onLoadFailed(@androidx.annotation.Nullable GlideException e, Object model, Target<T> target, boolean isFirstResource) {
-        FastImageOkHttpProgressGlideModule.forget(key);
         if (!(target instanceof ImageViewTarget)) {
             return false;
         }
@@ -44,11 +31,10 @@ public class FastImageRequestListener<T extends Drawable> implements RequestList
         ThemedReactContext context = (ThemedReactContext) view.getContext();
         EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
         int surfaceId = UIManagerHelper.getSurfaceId(view);
-        WritableMap errorEvent = new WritableNativeMap();
-        errorEvent.putString("error", e != null ? e.getMessage() : "Load Failed");
+        String error = e != null && e.getMessage() != null ? e.getMessage() : "Load Failed";
 
         if (dispatcher != null) {
-            dispatcher.dispatchEvent(new FastImageErrorEvent(surfaceId, view.getId(), errorEvent));
+            dispatcher.dispatchEvent(new FastImageErrorEvent(surfaceId, view.getId(), error));
             dispatcher.dispatchEvent(new FastImageLoadEndEvent(surfaceId, view.getId()));
         }
         return false;

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -13,7 +13,6 @@ import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.request.Request;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
-import com.bumptech.glide.load.resource.gif.GifDrawable;
 import com.facebook.react.bridge.ReadableMap;
 import com.dylanvann.fastimage.events.FastImageErrorEvent;
 import com.dylanvann.fastimage.events.FastImageLoadStartEvent;
@@ -27,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import android.os.Build;
 import android.util.Log;
 
 class FastImageViewWithUrl extends AppCompatImageView {
@@ -38,10 +36,13 @@ class FastImageViewWithUrl extends AppCompatImageView {
     private int mBlurRadius = 0;
     private int mBlurRadiusPrevious = 0;
     public GlideUrl glideUrl;
+    @Nullable
+    final RequestManager requestManager;
     private String mTransition = "none"; // "none" | "fade"
 
-    public FastImageViewWithUrl(Context context) {
+    public FastImageViewWithUrl(Context context, @Nullable RequestManager requestManager) {
         super(context);
+        this.requestManager = requestManager;
     }
 
     public void setSource(@Nullable ReadableMap source) {
@@ -52,6 +53,13 @@ class FastImageViewWithUrl extends AppCompatImageView {
     public void setDefaultSource(@Nullable Drawable source) {
         mNeedsReload = true;
         mDefaultSource = source;
+    }
+
+    public void setResizeMode(ScaleType scaleType) {
+        if (getScaleType() != scaleType) {
+            setScaleType(scaleType);
+            mNeedsReload = true;
+        }
     }
 
     public void setBlurRadius(@Nullable Integer blurRadius) {
@@ -80,18 +88,14 @@ class FastImageViewWithUrl extends AppCompatImageView {
             @NonNull Map<String, List<FastImageViewWithUrl>> viewsForUrlsMap) {
         if (!mNeedsReload)
             return;
+        mNeedsReload = false;
+        clearView(requestManager);
+        clearProgressListener(viewsForUrlsMap);
 
         if ((mSource == null ||
                 !mSource.hasKey("uri") ||
                 isNullOrEmpty(mSource.getString("uri"))) &&
                 mDefaultSource == null) {
-
-            // Cancel existing requests.
-            clearView(requestManager);
-
-            if (glideUrl != null) {
-                FastImageOkHttpProgressGlideModule.forget(glideUrl.toStringUrl());
-            }
 
             // Clear the image.
             setImageDrawable(null);
@@ -99,7 +103,7 @@ class FastImageViewWithUrl extends AppCompatImageView {
             ThemedReactContext context = (ThemedReactContext) getContext();
             EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, getId());
             int surfaceId = UIManagerHelper.getSurfaceId(this);
-            FastImageErrorEvent event = new FastImageErrorEvent(surfaceId, getId(), mSource);
+            FastImageErrorEvent event = new FastImageErrorEvent(surfaceId, getId(), "Invalid source: missing URI");
             if (dispatcher != null) {
                 dispatcher.dispatchEvent(event);
             }
@@ -113,16 +117,10 @@ class FastImageViewWithUrl extends AppCompatImageView {
             ThemedReactContext context = (ThemedReactContext) getContext();
             EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, getId());
             int surfaceId = UIManagerHelper.getSurfaceId(this);
-            FastImageErrorEvent event = new FastImageErrorEvent(surfaceId, getId(), mSource);
+            FastImageErrorEvent event = new FastImageErrorEvent(surfaceId, getId(), "Invalid source: resource not found");
 
             if (dispatcher != null) {
                 dispatcher.dispatchEvent(event);
-            }
-            // Cancel existing requests.
-            clearView(requestManager);
-
-            if (glideUrl != null) {
-                FastImageOkHttpProgressGlideModule.forget(glideUrl.toStringUrl());
             }
             // Clear the image.
             setImageDrawable(null);
@@ -132,9 +130,7 @@ class FastImageViewWithUrl extends AppCompatImageView {
         // `imageSource` may be null and we still continue, if `defaultSource` is not null
         final GlideUrl glideUrl = imageSource == null ? null : imageSource.getGlideUrl();
 
-        // Cancel existing request.
         this.glideUrl = glideUrl;
-        clearView(requestManager);
 
         String key = glideUrl == null ? null : glideUrl.toStringUrl();
 
@@ -151,7 +147,6 @@ class FastImageViewWithUrl extends AppCompatImageView {
 
         ThemedReactContext context = (ThemedReactContext) getContext();
         if (imageSource != null) {
-            // This is an orphan even without a load/loadend when only loading a placeholder
             // This is an orphan event without a load/loadend when only loading a placeholder
             EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, getId());
             int surfaceId = UIManagerHelper.getSurfaceId(this);
@@ -178,7 +173,7 @@ class FastImageViewWithUrl extends AppCompatImageView {
                                 .fallback(mDefaultSource)); // null will not be treated as error
 
                 if (key != null) {
-                    builder.listener(new FastImageRequestListener(key));
+                    builder.listener(new FastImageRequestListener<>(key));
                 }
 
                 if ("fade".equals(mTransition)) {
@@ -191,6 +186,18 @@ class FastImageViewWithUrl extends AppCompatImageView {
                 imageSource != null ? imageSource.getUri().toString() : "null", e.getMessage()), e);
             }
         }
+    }
+
+    public void clearProgressListener(@NonNull Map<String, List<FastImageViewWithUrl>> viewsForUrlsMap) {
+        if (glideUrl == null) return;
+        String key = glideUrl.toStringUrl();
+        List<FastImageViewWithUrl> views = viewsForUrlsMap.get(key);
+        if (views != null) views.remove(this);
+        if (views == null || views.isEmpty()) {
+            viewsForUrlsMap.remove(key);
+            FastImageOkHttpProgressGlideModule.forget(key);
+        }
+        glideUrl = null;
     }
 
     public void clearView(@Nullable RequestManager requestManager) {

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageErrorEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageErrorEvent.java
@@ -1,21 +1,18 @@
 package com.dylanvann.fastimage.events;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
 
 public class FastImageErrorEvent extends Event<FastImageErrorEvent> {
 
-    @Nullable
-    private final ReadableMap mSource;
+    private final String error;
 
-    public FastImageErrorEvent(int surfaceId, int viewTag, @Nullable ReadableMap source) {
+    public FastImageErrorEvent(int surfaceId, int viewTag, @NonNull String error) {
         super(surfaceId, viewTag);
-        mSource = source;
+        this.error = error;
     }
     @NonNull
     @Override
@@ -26,9 +23,7 @@ public class FastImageErrorEvent extends Event<FastImageErrorEvent> {
     @Override
     protected WritableMap getEventData() {
         WritableMap eventData = Arguments.createMap();
-        if (mSource != null) {
-            eventData.putString("error", "Invalid source prop:" + mSource);
-        }
+        eventData.putString("error", error);
         return eventData;
     }
 }

--- a/android/src/newarch/java/com/FastImageViewManager.java
+++ b/android/src/newarch/java/com/FastImageViewManager.java
@@ -16,6 +16,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.dylanvann.fastimage.events.FastImageProgressEvent;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
@@ -43,8 +44,6 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     static final String REACT_ON_PROGRESS_EVENT = "onFastImageProgress";
     private static final Map<String, List<FastImageViewWithUrl>> VIEWS_FOR_URLS = new WeakHashMap<>();
 
-    @Nullable
-    private RequestManager requestManager = null;
     private final ViewManagerDelegate<FastImageViewWithUrl> mDelegate;
 
 
@@ -66,11 +65,12 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     @NonNull
     @Override
     protected FastImageViewWithUrl createViewInstance(@NonNull ThemedReactContext reactContext) {
+        RequestManager requestManager = null;
         if (isValidContextForGlide(reactContext)) {
             requestManager = Glide.with(reactContext);
         }
 
-        return new FastImageViewWithUrl(reactContext);
+        return new FastImageViewWithUrl(reactContext, requestManager);
     }
     @Override
     @ReactProp(name = "source")
@@ -97,7 +97,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     @ReactProp(name = "resizeMode")
     public void setResizeMode(FastImageViewWithUrl view, String resizeMode) {
         final FastImageViewWithUrl.ScaleType scaleType = FastImageViewConverter.getScaleType(resizeMode);
-        view.setScaleType(scaleType);
+        view.setResizeMode(scaleType);
     }
     @Override
     @ReactProp(name = "blurRadius")
@@ -114,17 +114,9 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     @Override
     public void onDropViewInstance(@NonNull FastImageViewWithUrl view) {
         // This will cancel existing requests.
-        view.clearView(requestManager);
+        view.clearView(view.requestManager);
 
-        if (view.glideUrl != null) {
-            final String key = view.glideUrl.toString();
-            FastImageOkHttpProgressGlideModule.forget(key);
-            List<FastImageViewWithUrl> viewsForKey = VIEWS_FOR_URLS.get(key);
-            if (viewsForKey != null) {
-                viewsForKey.remove(view);
-                if (viewsForKey.size() == 0) VIEWS_FOR_URLS.remove(key);
-            }
-        }
+        view.clearProgressListener(VIEWS_FOR_URLS);
 
         super.onDropViewInstance(view);
     }
@@ -142,23 +134,25 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
 
     @Override
     public void onProgress(String key, long bytesRead, long expectedLength) {
-        List<FastImageViewWithUrl> viewsForKey = VIEWS_FOR_URLS.get(key);
-        if (viewsForKey != null) {
-            for (FastImageViewWithUrl view : viewsForKey) {
-                ThemedReactContext context = (ThemedReactContext) view.getContext();
-                EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
-                int surfaceId = UIManagerHelper.getSurfaceId(context);
-                FastImageProgressEvent event = new FastImageProgressEvent(
-                        surfaceId,
-                        view.getId(),
-                        (int) bytesRead,
-                        (int) expectedLength);
+        UiThreadUtil.runOnUiThread(() -> {
+            List<FastImageViewWithUrl> viewsForKey = VIEWS_FOR_URLS.get(key);
+            if (viewsForKey != null) {
+                for (FastImageViewWithUrl view : viewsForKey) {
+                    ThemedReactContext context = (ThemedReactContext) view.getContext();
+                    EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
+                    int surfaceId = UIManagerHelper.getSurfaceId(context);
+                    FastImageProgressEvent event = new FastImageProgressEvent(
+                            surfaceId,
+                            view.getId(),
+                            (int) bytesRead,
+                            (int) expectedLength);
 
-                if (dispatcher != null) {
-                    dispatcher.dispatchEvent(event);
+                    if (dispatcher != null) {
+                        dispatcher.dispatchEvent(event);
+                    }
                 }
             }
-        }
+        });
     }
 
     @Override
@@ -211,6 +205,6 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     @Override
     protected void onAfterUpdateTransaction(@NonNull FastImageViewWithUrl view) {
         super.onAfterUpdateTransaction(view);
-        view.onAfterUpdate(this, requestManager, VIEWS_FOR_URLS);
+        view.onAfterUpdate(this, view.requestManager, VIEWS_FOR_URLS);
     }
 }

--- a/android/src/oldarch/java/com/FastImageViewManager.java
+++ b/android/src/oldarch/java/com/FastImageViewManager.java
@@ -16,6 +16,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.dylanvann.fastimage.events.FastImageProgressEvent;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
@@ -40,8 +41,6 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     static final String REACT_ON_PROGRESS_EVENT = "onFastImageProgress";
     private static final Map<String, List<FastImageViewWithUrl>> VIEWS_FOR_URLS = new WeakHashMap<>();
 
-    @Nullable
-    private RequestManager requestManager = null;
 
     @NonNull
     @Override
@@ -52,11 +51,12 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     @NonNull
     @Override
     protected FastImageViewWithUrl createViewInstance(@NonNull ThemedReactContext reactContext) {
+        RequestManager requestManager = null;
         if (isValidContextForGlide(reactContext)) {
             requestManager = Glide.with(reactContext);
         }
 
-        return new FastImageViewWithUrl(reactContext);
+        return new FastImageViewWithUrl(reactContext, requestManager);
     }
 
     @ReactProp(name = "source")
@@ -83,7 +83,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     @ReactProp(name = "resizeMode")
     public void setResizeMode(FastImageViewWithUrl view, String resizeMode) {
         final FastImageViewWithUrl.ScaleType scaleType = FastImageViewConverter.getScaleType(resizeMode);
-        view.setScaleType(scaleType);
+        view.setResizeMode(scaleType);
     }
 
     @ReactProp(name = "blurRadius")
@@ -99,17 +99,9 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     @Override
     public void onDropViewInstance(@NonNull FastImageViewWithUrl view) {
         // This will cancel existing requests.
-        view.clearView(requestManager);
+        view.clearView(view.requestManager);
 
-        if (view.glideUrl != null) {
-            final String key = view.glideUrl.toString();
-            FastImageOkHttpProgressGlideModule.forget(key);
-            List<FastImageViewWithUrl> viewsForKey = VIEWS_FOR_URLS.get(key);
-            if (viewsForKey != null) {
-                viewsForKey.remove(view);
-                if (viewsForKey.size() == 0) VIEWS_FOR_URLS.remove(key);
-            }
-        }
+        view.clearProgressListener(VIEWS_FOR_URLS);
 
         super.onDropViewInstance(view);
     }
@@ -127,23 +119,25 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
 
     @Override
     public void onProgress(String key, long bytesRead, long expectedLength) {
-        List<FastImageViewWithUrl> viewsForKey = VIEWS_FOR_URLS.get(key);
-        if (viewsForKey != null) {
-            for (FastImageViewWithUrl view : viewsForKey) {
-                ThemedReactContext context = (ThemedReactContext) view.getContext();
-                EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
-                int surfaceId = UIManagerHelper.getSurfaceId(context);
-                FastImageProgressEvent event = new FastImageProgressEvent(
-                        surfaceId,
-                        view.getId(),
-                        (int) bytesRead,
-                        (int) expectedLength);
+        UiThreadUtil.runOnUiThread(() -> {
+            List<FastImageViewWithUrl> viewsForKey = VIEWS_FOR_URLS.get(key);
+            if (viewsForKey != null) {
+                for (FastImageViewWithUrl view : viewsForKey) {
+                    ThemedReactContext context = (ThemedReactContext) view.getContext();
+                    EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
+                    int surfaceId = UIManagerHelper.getSurfaceId(context);
+                    FastImageProgressEvent event = new FastImageProgressEvent(
+                            surfaceId,
+                            view.getId(),
+                            (int) bytesRead,
+                            (int) expectedLength);
 
-                if (dispatcher != null) {
-                    dispatcher.dispatchEvent(event);
+                    if (dispatcher != null) {
+                        dispatcher.dispatchEvent(event);
+                    }
                 }
             }
-        }
+        });
     }
 
     @Override
@@ -196,6 +190,6 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     @Override
     protected void onAfterUpdateTransaction(@NonNull FastImageViewWithUrl view) {
         super.onAfterUpdateTransaction(view);
-        view.onAfterUpdate(this, requestManager, VIEWS_FOR_URLS);
+        view.onAfterUpdate(this, view.requestManager, VIEWS_FOR_URLS);
     }
 }


### PR DESCRIPTION
## Summary:

No JS API signature changes. Error text is corrected; invalid-source events no longer stringify the supplied source object. Native FastImageErrorEvent's internal constructor now takes a message instead of ReadableMap. The public FastImageRequestListener(String) constructor remains. This is complementary to #388: its Glide tag/cancellation fix is deliberately excluded here to avoid duplicating that contribution.

Reset the pending-reload flag after processing, while explicitly reloading when resizeMode changes. Bind each view to its own RequestManager instead of replacing the manager for every existing view when another Activity creates an image. Remove old URL membership on source changes/drop, retain same-URL listeners until the last view leaves, and access the view registry only on the UI thread. Send the actual load error string rather than a stringified source/map.

## Changelog:

- [ANDROID] [FIXED] - scope requests and progress tracking to each image view

## Test Plan:

Both architecture source sets compile against RN 0.87.1/Glide. Actual manager methods with context doubles reproduce Activity A receiving Activity B's manager and an invalid context borrowing it; both paths are isolated after the fix. Resize-mode changes still schedule a reload, unchanged modes do not. Actual registry cleanup retains the second same-URL view and forgets only after the last removal. Whole-library existing Jest/lint/type/build checks pass.

- Existing upstream Jest: 7 tests / 7 snapshots pass; lint, type-check, TypeScript build, and git diff --check pass on the combined review branch.
- React Doctor: 100/100 for changed React files.
- Diagnostic harnesses are isolated and not checked-in test files. Physical-device, signed-release, and pixel-level rendering checks were not performed.
- Applicable fixes are backported to published 8.13.0 in consumer commit c96bba89a3de647844e29627eb57e24454323cda, retaining release native dependency declarations and excluding the newer main-only Java raw-resource implementation. Consumer checks pass: immutable install, ESLint, both products on Android Debug and iOS arm64 Simulator Debug, four release-mode Metro bundles, 13 web targets and four browser extensions. Generated Fabric cache default is verified. No physical-device/signed-release check is claimed.
