### PR TITLE
fix(android): retain progress for unknown-length responses

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
@@ -73,38 +73,39 @@ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
     }
 
     private interface ResponseProgressListener {
-        void update(String key, long bytesRead, long contentLength);
+        void update(String key, long bytesRead, long contentLength, boolean done);
     }
 
     private static class DispatchingProgressListener implements ResponseProgressListener {
         private final Map<String, FastImageProgressListener> LISTENERS = new WeakHashMap<>();
         private final Map<String, Long> PROGRESSES = new HashMap<>();
 
-        void forget(String key) {
+        synchronized void forget(String key) {
             LISTENERS.remove(key);
             PROGRESSES.remove(key);
         }
 
-        void expect(String key, FastImageProgressListener listener) {
+        synchronized void expect(String key, FastImageProgressListener listener) {
             LISTENERS.put(key, listener);
         }
 
         @Override
-        public void update(final String key, final long bytesRead, final long contentLength) {
-            final FastImageProgressListener listener = LISTENERS.get(key);
-            if (listener == null) {
-                return;
+        public void update(final String key, final long bytesRead, final long contentLength, boolean done) {
+            final FastImageProgressListener listener;
+            final boolean dispatch;
+            synchronized (this) {
+                listener = LISTENERS.get(key);
+                if (listener == null) return;
+                dispatch = done || needsDispatch(key, bytesRead, contentLength, listener.getGranularityPercentage());
+                if (done || (contentLength >= 0 && contentLength <= bytesRead)) {
+                    forget(key);
+                }
             }
-            if (contentLength <= bytesRead) {
-                forget(key);
-            }
-            if (needsDispatch(key, bytesRead, contentLength, listener.getGranularityPercentage())) {
-                listener.onProgress(key, bytesRead, contentLength);
-            }
+            if (dispatch) listener.onProgress(key, bytesRead, contentLength);
         }
 
         private boolean needsDispatch(String key, long current, long total, float granularity) {
-            if (granularity == 0 || current == 0 || total == current) {
+            if (granularity == 0 || current == 0 || total <= 0 || total == current) {
                 return true;
             }
             float percent = 100f * current / total;
@@ -161,13 +162,10 @@ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
                 public long read(Buffer sink, long byteCount) throws IOException {
                     long bytesRead = super.read(sink, byteCount);
                     long fullLength = responseBody.contentLength();
-                    if (bytesRead == -1) {
-                        // this source is exhausted
-                        totalBytesRead = fullLength;
-                    } else {
+                    if (bytesRead != -1) {
                         totalBytesRead += bytesRead;
                     }
-                    progressListener.update(key, totalBytesRead, fullLength);
+                    progressListener.update(key, totalBytesRead, fullLength, bytesRead == -1);
                     return bytesRead;
                 }
             };


### PR DESCRIPTION
## Summary:

Unknown-length responses retain total=-1 but now report meaningful loaded bytes and subsequent progress. Known-length behavior and the public JS event shape are unchanged. No dependency changes.

Use EOF explicitly instead of treating contentLength=-1 as completion on the first read. Retain actual cumulative bytes at EOF, handle unknown/zero totals without division, and synchronize listener/progress bookkeeping while invoking external progress callbacks outside the monitor.

## Changelog:

- [ANDROID] [FIXED] - retain progress for unknown-length responses

## Test Plan:

Executed the actual compiled module with real OkHttp/Okio bodies: unknown-length progress events increase from one to three, final loaded bytes change from -1 to 4; the known-length case retains four events. A four-thread, 1,000-keys-per-thread exercise completes without leftover listener/progress entries. Both architecture Java compilation passes.

- Existing upstream Jest: 7 tests / 7 snapshots pass; lint, type-check, TypeScript build, and git diff --check pass on the combined review branch.
- React Doctor: 100/100 for changed React files.
- Diagnostic harnesses are isolated and not checked-in test files. Physical-device, signed-release, and pixel-level rendering checks were not performed.
- Applicable fixes are backported to published 8.13.0 in consumer commit c96bba89a3de647844e29627eb57e24454323cda, retaining release native dependency declarations and excluding the newer main-only Java raw-resource implementation. Consumer checks pass: immutable install, ESLint, both products on Android Debug and iOS arm64 Simulator Debug, four release-mode Metro bundles, 13 web targets and four browser extensions. Generated Fabric cache default is verified. No physical-device/signed-release check is claimed.
