### PR TITLE
fix(ios): scope preload headers to individual image requests

### DIFF
--- a/ios/FastImage/FFFastImageSource.h
+++ b/ios/FastImage/FFFastImageSource.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <SDWebImage/SDWebImageDefine.h>
 
 typedef NS_ENUM(NSInteger, FFFPriority) {
     FFFPriorityLow,
@@ -29,5 +30,7 @@ typedef NS_ENUM(NSInteger, FFFCacheControl) {
                    priority:(FFFPriority)priority
                     headers:(NSDictionary *)headers
                cacheControl:(FFFCacheControl)cacheControl;
+
+- (SDWebImageContext *)contextWithRequestHeaders:(SDWebImageContext *)context;
 
 @end

--- a/ios/FastImage/FFFastImageSource.mm
+++ b/ios/FastImage/FFFastImageSource.mm
@@ -1,4 +1,5 @@
 #import "FFFastImageSource.h"
+#import <SDWebImage/SDWebImageDownloaderRequestModifier.h>
 
 @implementation FFFastImageSource
 
@@ -15,6 +16,24 @@
         _cacheControl = cacheControl;
     }
     return self;
+}
+
+- (SDWebImageContext *)contextWithRequestHeaders:(SDWebImageContext *)context {
+    NSDictionary *headers = [self.headers copy];
+    if (headers.count == 0) return context;
+    id<SDWebImageDownloaderRequestModifier> previousModifier = context[SDWebImageContextDownloadRequestModifier];
+    SDWebImageDownloaderRequestModifier *modifier = [SDWebImageDownloaderRequestModifier requestModifierWithBlock:^NSURLRequest *(NSURLRequest *request) {
+        NSURLRequest *modifiedRequest = previousModifier ? [previousModifier modifiedRequestWithRequest:request] : request;
+        if (!modifiedRequest) return nil;
+        NSMutableURLRequest *result = [modifiedRequest mutableCopy];
+        for (NSString *header in headers) {
+            [result setValue:headers[header] forHTTPHeaderField:header];
+        }
+        return [result copy];
+    }];
+    NSMutableDictionary *result = [context mutableCopy] ?: [NSMutableDictionary new];
+    result[SDWebImageContextDownloadRequestModifier] = modifier;
+    return result;
 }
 
 @end

--- a/ios/FastImage/FFFastImageView.mm
+++ b/ios/FastImage/FFFastImageView.mm
@@ -263,17 +263,7 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
             return;
         }
 
-        // Set headers.
-        NSDictionary* headers = _source.headers;
-        SDWebImageDownloaderRequestModifier* requestModifier = [SDWebImageDownloaderRequestModifier requestModifierWithBlock: ^NSURLRequest* _Nullable (NSURLRequest* _Nonnull request) {
-            NSMutableURLRequest* mutableRequest = [request mutableCopy];
-            for (NSString* header in headers) {
-                NSString* value = headers[header];
-                [mutableRequest setValue: value forHTTPHeaderField: header];
-            }
-            return [mutableRequest copy];
-        }];
-        SDWebImageContext* context = @{SDWebImageContextDownloadRequestModifier: requestModifier};
+        SDWebImageContext* context = [_source contextWithRequestHeaders:nil];
 
         // Set priority.
         SDWebImageOptions options = SDWebImageRetryFailed | SDWebImageHandleCookies;

--- a/ios/FastImage/FFFastImageViewModule.mm
+++ b/ios/FastImage/FFFastImageViewModule.mm
@@ -11,16 +11,15 @@ RCT_EXPORT_MODULE(FastImageViewModule)
 
 RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)
 {
-    NSMutableArray *urls = [NSMutableArray arrayWithCapacity:sources.count];
-
-    [sources enumerateObjectsUsingBlock:^(FFFastImageSource * _Nonnull source, NSUInteger idx, BOOL * _Nonnull stop) {
-        [source.headers enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString* header, BOOL *stop) {
-            [[SDWebImageDownloader sharedDownloader] setValue:header forHTTPHeaderField:key];
-        }];
-        [urls setObject:source.url atIndexedSubscript:idx];
-    }];
-
-    [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:urls];
+    SDWebImagePrefetcher *prefetcher = [SDWebImagePrefetcher sharedImagePrefetcher];
+    for (FFFastImageSource *source in sources) {
+        if (!source.url) continue;
+        [prefetcher prefetchURLs:@[source.url]
+                       options:prefetcher.options
+                       context:[source contextWithRequestHeaders:prefetcher.context]
+                      progress:nil
+                     completed:nil];
+    }
 }
 
 RCT_EXPORT_METHOD(clearMemoryCache:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
## Summary:

No JS API change. Preload headers intentionally stop persisting globally or crossing into other requests. Applications that accidentally relied on a previous preload setting global headers must pass headers explicitly. Existing prefetcher options and context are preserved; no new cache/priority semantics are introduced.

Replace shared-downloader header mutation during preload with per-source request contexts. Share the header-composition helper with normal image loading, preserve any existing prefetch context/request modifier (including cancellation), copy headers for a stable request snapshot, and skip sources without URLs. Continue using the shared prefetcher's bounded operation queue and existing options.

## Changelog:

- [IOS] [FIXED] - scope preload headers to individual image requests

## Test Plan:

All changed Apple files compile against the consumer RN 0.87.1/SDWebImage simulator SDKs. Compiled actual preload/helper methods with Foundation/SDK doubles: three source contexts use their own header values instead of all receiving the last value; no global header writes; nil URLs no longer throw; custom modifiers/options/context, cancellation, copied headers and empty-header fast path pass. No real credentials or network requests used.

- Existing upstream Jest: 7 tests / 7 snapshots pass; lint, type-check, TypeScript build, and git diff --check pass on the combined review branch.
- React Doctor: 100/100 for changed React files.
- Diagnostic harnesses are isolated and not checked-in test files. Physical-device, signed-release, and pixel-level rendering checks were not performed.
- Applicable fixes are backported to published 8.13.0 in consumer commit c96bba89a3de647844e29627eb57e24454323cda, retaining release native dependency declarations and excluding the newer main-only Java raw-resource implementation. Consumer checks pass: immutable install, ESLint, both products on Android Debug and iOS arm64 Simulator Debug, four release-mode Metro bundles, 13 web targets and four browser extensions. Generated Fabric cache default is verified. No physical-device/signed-release check is claimed.
