### PR TITLE
fix(ios): isolate image request state and preserve original rendering inputs

### DIFF
--- a/ios/FastImage/FFFastImageView.mm
+++ b/ios/FastImage/FFFastImageView.mm
@@ -16,6 +16,8 @@
 @property(nonatomic, assign) BOOL hasErrored;
 // Whether the latest change of props requires the image to be reloaded
 @property(nonatomic, assign) BOOL needsReload;
+@property(nonatomic, assign) NSUInteger loadGeneration;
+@property(nonatomic, strong) UIImage *originalImage;
 
 @property(nonatomic, strong) NSDictionary* onLoadEvent;
 
@@ -33,6 +35,7 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
             @"width": [NSNumber numberWithDouble: image.size.width],
             @"height": [NSNumber numberWithDouble: image.size.height]
     };
+    self.onLoadEvent = onLoadEvent;
     #ifdef RCT_NEW_ARCH_ENABLED
         if (_eventEmitter != nullptr) {
             std::dynamic_pointer_cast<const facebook::react::FastImageViewEventEmitter>(_eventEmitter)
@@ -99,7 +102,7 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
     #ifdef RCT_NEW_ARCH_ENABLED
         if (_eventEmitter != nullptr) {
             std::dynamic_pointer_cast<const facebook::react::FastImageViewEventEmitter>(_eventEmitter)
-            ->onFastImageError(facebook::react::FastImageViewEventEmitter::OnFastImageError{.error = static_cast<std::string>([error.localizedDescription UTF8String])});
+            ->onFastImageError(facebook::react::FastImageViewEventEmitter::OnFastImageError{.error = std::string([msg UTF8String])});
         }
     #else
         if (self.onFastImageError) {
@@ -149,7 +152,7 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
 
 - (void) setOnFastImageLoadEnd: (RCTDirectEventBlock)onFastImageLoadEnd {
     _onFastImageLoadEnd = onFastImageLoadEnd;
-    if (self.hasCompleted && _onFastImageLoadEnd) {
+    if ((self.hasCompleted || self.hasErrored) && _onFastImageLoadEnd) {
         _onFastImageLoadEnd(@{});
     }
 }
@@ -169,35 +172,29 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
 }
 
 - (void) setOnFastImageLoadStart: (RCTDirectEventBlock)onFastImageLoadStart {
-    if (_source && !self.hasSentOnLoadStart) {
-        _onFastImageLoadStart = onFastImageLoadStart;
-        if (onFastImageLoadStart) {
-            onFastImageLoadStart(@{});
-        }
-        self.hasSentOnLoadStart = YES;
-    } else {
-        _onFastImageLoadStart = onFastImageLoadStart;
-        self.hasSentOnLoadStart = NO;
+    _onFastImageLoadStart = onFastImageLoadStart;
+    if (_onFastImageLoadStart && _source.url && !self.needsReload &&
+        !self.hasSentOnLoadStart && !self.hasCompleted && !self.hasErrored) {
+        [self onLoadStartEvent];
     }
 }
 
 - (void) setImageColor: (UIColor*)imageColor {
-    if (imageColor != nil) {
+    if (_imageColor != imageColor && ![_imageColor isEqual:imageColor]) {
         _imageColor = imageColor;
-        if (super.image) {
-            super.image = [self makeImage: super.image withTint: self.imageColor];
-        }
+        [self setImage:self.originalImage];
     }
 }
 
 - (void)setBlurRadius:(CGFloat)blurRadius {
     if (_blurRadius != blurRadius) {
         _blurRadius = blurRadius;
-        _needsReload = YES;
+        [self setImage:self.originalImage];
     }
 }
 
 - (UIImage*) makeImage: (UIImage*)image withTint: (UIColor*)color {
+    if (image.size.width <= 0 || image.size.height <= 0) return image;
     UIImage* newImage = [image imageWithRenderingMode: UIImageRenderingModeAlwaysTemplate];
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:image.size];
     newImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
@@ -208,6 +205,11 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
 }
 
 - (void) setImage: (UIImage*)image {
+    self.originalImage = image;
+    if (!image) {
+        super.image = nil;
+        return;
+    }
     if (_blurRadius && _blurRadius > 0) {
         FFFastImageBlurTransformation *transformation =
             [[FFFastImageBlurTransformation alloc] initWithRadius:_blurRadius];
@@ -227,6 +229,11 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
 
 - (void) setSource: (FFFastImageSource*)source {
     if (_source != source) {
+        BOOL sameSource = _source && source &&
+            (_source.url == source.url || [_source.url isEqual:source.url]) &&
+            (_source.headers == source.headers || [_source.headers isEqual:source.headers]) &&
+            _source.priority == source.priority && _source.cacheControl == source.cacheControl;
+        if (sameSource) return;
         _source = source;
         _needsReload = YES;
     }
@@ -247,8 +254,15 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
 
 - (void) reloadImage {
     _needsReload = NO;
+    self.loadGeneration += 1;
+    [self sd_cancelCurrentImageLoad];
+    self.hasSentOnLoadStart = NO;
+    self.hasCompleted = NO;
+    self.hasErrored = NO;
+    self.onLoadEvent = nil;
+    self.lastErrorEvent = nil;
 
-    if (_source) {
+    if (_source.url) {
         // Load base64 images.
         NSString* url = [_source.url absoluteString];
         if (url && [url hasPrefix: @"data:image"]) {
@@ -256,9 +270,14 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
             // Use SDWebImage API to support external format like WebP images
             UIImage* image = [UIImage sd_imageWithData: [NSData dataWithContentsOfURL: _source.url]];
             [self setImage: image];
-            [self onProgressEvent:1 expectedSize:1];
-            self.hasCompleted = YES;
-            [self sendOnLoad: image];
+            if (image) {
+                [self onProgressEvent:1 expectedSize:1];
+                self.hasCompleted = YES;
+                [self sendOnLoad: image];
+            } else {
+                self.hasErrored = YES;
+                [self onErrorEvent:[NSError errorWithDomain:@"FastImage" code:1 userInfo:@{NSLocalizedDescriptionKey: @"Failed to decode image data"}]];
+            }
             [self onLoadEndEvent];
             return;
         }
@@ -300,40 +319,48 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
                 break;
         }
         [self onLoadStartEvent];
-        self.hasCompleted = NO;
-        self.hasErrored = NO;
-
         [self downloadImage: _source options: options context: context];
-    } else if (_defaultSource) {
+    } else {
         [self setImage: _defaultSource];
     }
 }
 
 - (void) downloadImage: (FFFastImageSource*)source options: (SDWebImageOptions)options context: (SDWebImageContext*)context {
     __weak FFFastImageView *weakSelf = self; // Always use a weak reference to self in blocks
+    NSUInteger generation = self.loadGeneration;
     // transition: default to none; enable fade if requested
-    if (self.transition && [self.transition isEqualToString:@"fade"]) {
-        self.sd_imageTransition = SDWebImageTransition.fadeTransition;
-    }
-    [self sd_setImageWithURL: _source.url
+    self.sd_imageTransition = [self.transition isEqualToString:@"fade"] ? SDWebImageTransition.fadeTransition : nil;
+    [self sd_setImageWithURL: source.url
             placeholderImage: _defaultSource
                      options: options
                      context: context
                     progress: ^(NSInteger receivedSize, NSInteger expectedSize, NSURL* _Nullable targetURL) {
-        [self onProgressEvent:receivedSize expectedSize:expectedSize];
+        dispatch_block_t reportProgress = ^{
+            FFFastImageView *view = weakSelf;
+            if (view && view.loadGeneration == generation && !view.hasCompleted && !view.hasErrored) {
+                [view onProgressEvent:receivedSize expectedSize:expectedSize];
+            }
+        };
+        if ([NSThread isMainThread]) {
+            reportProgress();
+        } else {
+            dispatch_async(dispatch_get_main_queue(), reportProgress);
+        }
                     } completed: ^(UIImage* _Nullable image,
                     NSError* _Nullable error,
                     SDImageCacheType cacheType,
                     NSURL* _Nullable imageURL) {
+                FFFastImageView *view = weakSelf;
+                if (!view || view.loadGeneration != generation) return;
                 if (error) {
-                    weakSelf.hasErrored = YES;
-                    [weakSelf onErrorEvent:error];
+                    view.hasErrored = YES;
+                    [view onErrorEvent:error];
 
-                    [weakSelf onLoadEndEvent];
+                    [view onLoadEndEvent];
                 } else {
-                    weakSelf.hasCompleted = YES;
-                    [weakSelf sendOnLoad: image];
-                    [weakSelf onLoadEndEvent];
+                    view.hasCompleted = YES;
+                    [view sendOnLoad: image];
+                    [view onLoadEndEvent];
                 }
             }];
 }

--- a/ios/FastImage/FFFastImageViewComponentView.mm
+++ b/ios/FastImage/FFFastImageViewComponentView.mm
@@ -121,7 +121,7 @@ using namespace facebook::react;
     // so we call it after updating the props. If the _eventEmitter is not present yet,
     // we postpone the update till it is set in `updateEventEmitter` since we want to send
     // events to JS.
-    if (!_eventEmitter) {
+    if (!fastImageView.eventEmitter) {
         _shouldPostponeUpdate = YES;
     } else {
         _shouldPostponeUpdate = NO;
@@ -136,6 +136,7 @@ using namespace facebook::react;
     [fastImageView setEventEmitter:std::static_pointer_cast<FastImageViewEventEmitter const>(eventEmitter)];
     if (_shouldPostponeUpdate) {
         // we do the update here since it is the moment we can send events to JS
+        _shouldPostponeUpdate = NO;
         [fastImageView didSetProps:nil];
     }
 }
@@ -143,6 +144,7 @@ using namespace facebook::react;
 - (void)prepareForRecycle
 {
     [super prepareForRecycle];
+    _shouldPostponeUpdate = NO;
     fastImageView = [[FFFastImageView alloc] initWithFrame:self.bounds];
     self.contentView = fastImageView;
 }


### PR DESCRIPTION
## Summary:

No JS API signature changes. Invalid base64 image data now reports error/end rather than a successful zero-size load. Redundant source/style updates no longer issue extra loads; clearing a source clears the old image; stale progress/completion events are suppressed. Tint/blur updates render the original image without a new network request. No image-format or cache-option changes.

Cancel/reset old requests when replacing or clearing a source; ignore stale callbacks using a generation counter and avoid strongly retaining the view from progress blocks. Reuse the original image when tint/blur changes, handle tint removal, avoid refetching equivalent source values, reset fade-to-none transitions, and correctly replay load/error/end state to late handlers. Guard invalid base64 decoding and Fabric error fallback strings; postpone recycled Fabric view updates until its actual emitter is available.

## Changelog:

- [IOS] [FIXED] - isolate image request state and preserve original rendering inputs

## Test Plan:

All five changed Apple source files compile against actual RN 0.87.1/SDWebImage simulator headers. Compiled actual lifecycle methods with Foundation and narrow UIKit/downloader doubles: 11 baseline/fixed checks cover equivalent-source reloads, tint reset, blur reload avoidance, saved load payload, late error/end, duplicate load-start, source clearing, stale completion/progress, fade reset, and weak view retention. Rendering doubles verify input/state handling, not pixel output or physical-device behavior.

- Existing upstream Jest: 7 tests / 7 snapshots pass; lint, type-check, TypeScript build, and git diff --check pass on the combined review branch.
- React Doctor: 100/100 for changed React files.
- Diagnostic harnesses are isolated and not checked-in test files. Physical-device, signed-release, and pixel-level rendering checks were not performed.
- Applicable fixes are backported to published 8.13.0 in consumer commit c96bba89a3de647844e29627eb57e24454323cda, retaining release native dependency declarations and excluding the newer main-only Java raw-resource implementation. Consumer checks pass: immutable install, ESLint, both products on Android Debug and iOS arm64 Simulator Debug, four release-mode Metro bundles, 13 web targets and four browser extensions. Generated Fabric cache default is verified. No physical-device/signed-release check is claimed.
