### PR TITLE
fix(ci): restore package metadata when nightly publishing fails

### DIFF
--- a/publish-nightly.sh
+++ b/publish-nightly.sh
@@ -12,7 +12,9 @@ if [ -z "$RELEASE_VERSION" ]; then
   exit 1
 fi
 # Backup the current package.json
-cp package.json package.json.bak
+package_backup=$(mktemp)
+cp package.json "$package_backup"
+trap 'mv "$package_backup" package.json' EXIT
 
 # Update package.json with the nightly version
 node -e "
@@ -25,6 +27,3 @@ fs.writeFileSync(path, JSON.stringify(pkg, null, 2));
 
 # Publish the package with the nightly tag
 npm publish --tag nightly
-
-# Revert package.json to the original version
-mv package.json.bak package.json


### PR DESCRIPTION
## Summary:

No version format or publish-command change. Failed publishing retains its original nonzero exit status while restoring the original package metadata. No live publishing was performed.

Use a unique temporary backup and an EXIT trap so package.json is restored even when npm publish fails under set -e. Avoid overwriting a pre-existing package.json.bak.

## Changelog:

- [INTERNAL] [FIXED] - restore package metadata when nightly publishing fails

## Test Plan:

bash -n passes. Ran the actual baseline/changed script in isolated directories with a stub npm executable: success and injected exit 42 both preserve their exit status; failure leaves modified metadata before and restores byte-identical metadata after.

- Existing upstream Jest: 7 tests / 7 snapshots pass; lint, type-check, TypeScript build, and git diff --check pass on the combined review branch.
- React Doctor: 100/100 for changed React files.
- Diagnostic harnesses are isolated and not checked-in test files. Physical-device, signed-release, and pixel-level rendering checks were not performed.
- Applicable fixes are backported to published 8.13.0 in consumer commit c96bba89a3de647844e29627eb57e24454323cda, retaining release native dependency declarations and excluding the newer main-only Java raw-resource implementation. Consumer checks pass: immutable install, ESLint, both products on Android Debug and iOS arm64 Simulator Debug, four release-mode Metro bundles, 13 web targets and four browser extensions. Generated Fabric cache default is verified. No physical-device/signed-release check is claimed.
