### PR TITLE
fix: defaultSource not applied on iOS new architecture (Fabric)

### DIFF
--- a/ios/FastImage/FFFastImageViewComponentView.mm
+++ b/ios/FastImage/FFFastImageViewComponentView.mm
@@ -12,10 +12,27 @@
 
 using namespace facebook::react;
 
+// Every FastImage instance re-runs updateProps (and thus re-decodes
+// defaultSource) on essentially every render pass. That's fine for a
+// one-off image, but a grid with many tiles sharing the same placeholder
+// (e.g. a stamp collection) was measured to visibly stall the main thread
+// when each tile redecoded the identical placeholder from scratch. Cache
+// the decoded UIImage per source string so repeats are free.
+static NSCache<NSString *, UIImage *> *FFDefaultSourceCache()
+{
+    static NSCache<NSString *, UIImage *> *cache;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cache = [NSCache new];
+    });
+    return cache;
+}
+
 @implementation FFFastImageViewComponentView
 {
     FFFastImageView *fastImageView;
     BOOL _shouldPostponeUpdate;
+    NSString *_lastDefaultSourceString;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -116,6 +133,30 @@ using namespace facebook::react;
     }
     fastImageView.transition = transition;
 
+    NSString *defaultSourceString = RCTNSStringFromStringNilIfEmpty(newViewProps.defaultSource);
+    if (defaultSourceString != _lastDefaultSourceString && ![defaultSourceString isEqualToString:_lastDefaultSourceString]) {
+        _lastDefaultSourceString = defaultSourceString;
+        if (!defaultSourceString) {
+            fastImageView.defaultSource = nil;
+        } else {
+            UIImage *cached = [FFDefaultSourceCache() objectForKey:defaultSourceString];
+            if (cached) {
+                fastImageView.defaultSource = cached;
+            } else {
+                // Wrap in the same {uri, __packager_asset} shape resolveAssetSource()
+                // normally produces — a bare string loses the packager-asset flag, so
+                // RCTConvert refuses to synchronously fetch it when Metro serves the
+                // asset over http (dev builds), even though the file scheme case still
+                // works fine either way (release/bundled assets).
+                UIImage *decoded = [RCTConvert UIImage:@{ @"uri": defaultSourceString, @"__packager_asset": @YES }];
+                if (decoded) {
+                    [FFDefaultSourceCache() setObject:decoded forKey:defaultSourceString];
+                }
+                fastImageView.defaultSource = decoded;
+            }
+        }
+    }
+
     [super updateProps:props oldProps:oldProps];
     // this method decides whether to reload the image based on changed props
     // so we call it after updating the props. If the _eventEmitter is not present yet,
@@ -145,6 +186,7 @@ using namespace facebook::react;
     [super prepareForRecycle];
     fastImageView = [[FFFastImageView alloc] initWithFrame:self.bounds];
     self.contentView = fastImageView;
+    _lastDefaultSourceString = nil;
 }
 
 @end

--- a/src/__snapshots__/index.test.tsx.snap
+++ b/src/__snapshots__/index.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`FastImage (iOS) renders defaultSource 1`] = `
   }
 >
   <FastImageView
-    defaultSource="[object Object]"
+    defaultSource={null}
     resizeMode="cover"
     style={
       {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -168,21 +168,20 @@ const resolveDefaultSource = (
     if (!defaultSource) {
         return null
     }
-    if (Platform.OS === 'android') {
-        // Android receives a URI string, and resolves into a Drawable using RN's methods.
-        const resolved = Image.resolveAssetSource(
-            defaultSource as ImageRequireSource,
-        )
+    // Both platforms need a resolved URI string, not the raw opaque asset
+    // number `require()` returns — RCTConvert's UIImage: (iOS) and
+    // ResourceDrawableIdHelper (Android) both expect an actual uri/path,
+    // not `String(assetId)`, which crashes trying to load "assets/<id>"
+    // as a bundle-relative file.
+    const resolved = Image.resolveAssetSource(
+        defaultSource as ImageRequireSource,
+    )
 
-        if (resolved) {
-            return resolved.uri
-        }
-
-        return null
+    if (resolved) {
+        return resolved.uri
     }
-    // iOS or other number mapped assets
-    // In iOS the number is passed, and bridged automatically into a UIImage
-    return defaultSource
+
+    return null
 }
 
 function FastImageBase({


### PR DESCRIPTION
## Summary
- `FFFastImageViewComponentView`'s (iOS Fabric) `updateProps` never read the `defaultSource` prop out of `FastImageViewProps`, so on iOS with the new architecture enabled, `defaultSource` was a silent no-op — the old-arch `FFFastImageViewManager` handled it correctly, but the Fabric component view was simply missing the wiring. Added it, mirroring what Android's `newarch/FastImageViewManager.java` already does.
- `resolveDefaultSource()` (shared JS) only called `Image.resolveAssetSource()` on Android; on iOS it forwarded the raw opaque `require()` asset id, stringified. That id isn't a valid image source for `RCTConvert UIImage:` — it doesn't crash outright, but fails to load (in dev, over the Metro packager, since the flattened string loses the `__packager_asset` marker `RCTConvert` needs to fetch it synchronously). Now iOS resolves the asset the same way Android does.
- Because a list of many tiles can share one `defaultSource` (e.g. a grid of stamps/placeholders), and Fabric calls `updateProps` on every prop diff (including from cell recycling), decoding the placeholder via `RCTConvert UIImage:` synchronously on every single update was measurably slow on a real device. The decoded `UIImage` is now cached by source string and skipped when unchanged from the previous update.

## Test plan
- [x] `yarn jest` — all existing tests pass; updated the one snapshot that had captured the previous broken output (`defaultSource="[object Object]"`)
- [x] `yarn type-check`
- [x] `yarn eslint src/index.tsx`
- [x] Manually verified on a real iPhone (new architecture enabled) in a consumer app: `defaultSource` now renders correctly for a `FastImage` grid, including while served over the Metro dev server, with no perceptible main-thread stall from repeated redecoding during scroll.